### PR TITLE
fix: Don't remove the token file when cleaning the repo

### DIFF
--- a/util/git_main.sh
+++ b/util/git_main.sh
@@ -2,4 +2,4 @@
 git checkout main
 git fetch
 git reset --hard origin/main
-git clean -fdx
+git clean -fdx -e github_token.py


### PR DESCRIPTION
Resolves #73